### PR TITLE
Make scope creation optional

### DIFF
--- a/act_as_time_as_boolean.gemspec
+++ b/act_as_time_as_boolean.gemspec
@@ -16,10 +16,9 @@ Gem::Specification.new do |s|
   s.add_dependency 'activesupport', '>= 3.2'
 
   s.add_development_dependency 'rake'
-  s.add_development_dependency 'coveralls', '~> 0.6'
-  s.add_development_dependency 'json', '~> 1.7.7'
-  s.add_development_dependency 'combustion', '~> 0.5.1'
-  s.add_development_dependency 'rspec-rails', '~> 2.14'
-  s.add_development_dependency 'sqlite3', '~> 1.3.3'
-  s.add_development_dependency 'activerecord', '~> 4.0.4'
+  s.add_development_dependency 'coveralls'
+  s.add_development_dependency 'combustion'
+  s.add_development_dependency 'rspec-rails'
+  s.add_development_dependency 'sqlite3'
+  s.add_development_dependency 'activerecord'
 end

--- a/lib/act_as_time_as_boolean/concern.rb
+++ b/lib/act_as_time_as_boolean/concern.rb
@@ -25,9 +25,12 @@ module ActAsTimeAsBoolean
         save!
       end
 
-      scope field, -> {
-        where "#{table_name}.#{field}_at IS NOT NULL AND #{table_name}.#{field}_at <= ?", Time.current
-      }
+      unless options[:scope] == false
+        scope_name = options[:scope] || field
+        scope scope_name, -> {
+          where "#{table_name}.#{field}_at IS NOT NULL AND #{table_name}.#{field}_at <= ?", Time.current
+        }
+      end
 
       if options[:opposite]
         opposite = options[:opposite]

--- a/spec/internal/app/models/article_with_scope.rb
+++ b/spec/internal/app/models/article_with_scope.rb
@@ -1,0 +1,6 @@
+class ArticleWithScope < ActiveRecord::Base
+  include ActAsTimeAsBoolean
+  self.table_name= 'article'
+
+  time_as_boolean :active, scope: :reactive
+end

--- a/spec/internal/app/models/article_with_scope_false.rb
+++ b/spec/internal/app/models/article_with_scope_false.rb
@@ -1,0 +1,6 @@
+class ArticleWithScopeFalse < ActiveRecord::Base
+  include ActAsTimeAsBoolean
+  self.table_name= 'article'
+
+  time_as_boolean :active, scope: false
+end

--- a/spec/lib/act_as_time_as_boolean_spec.rb
+++ b/spec/lib/act_as_time_as_boolean_spec.rb
@@ -30,6 +30,9 @@ describe ActAsTimeAsBoolean do
       it 'defines active= method' do
         subject.should include(:active=)
       end
+      it 'defines active! method' do
+        subject.should include(:active!)
+      end
     end
 
     describe 'with :active and opposite param' do
@@ -50,34 +53,29 @@ describe ActAsTimeAsBoolean do
       it 'defines inactive? method' do
         subject.should include(:inactive?)
       end
+      it 'defines inactive! method' do
+        subject.should include(:inactive!)
+      end
     end
 
     describe 'scopes' do
       describe 'with :active param' do
-        subject { Article.new }
+        subject { Article }
 
         it 'define active scope' do
-          subject.class.methods.should include(:active)
-        end
-
-        it 'defines active! method' do
-          subject.methods.should include(:active!)
+          subject.methods.should include(:active)
         end
       end
 
       describe 'with :active and opposite param' do
-        subject { ArticleWithOpposite.new }
+        subject { ArticleWithOpposite }
 
         it 'define active scope' do
-          subject.class.methods.should include(:active)
+          subject.methods.should include(:active)
         end
 
         it 'define inactive scope' do
-          subject.class.methods.should include(:inactive)
-        end
-
-        it 'defines inactive! method' do
-          subject.methods.should include(:inactive!)
+          subject.methods.should include(:inactive)
         end
       end
     end
@@ -89,11 +87,11 @@ describe ActAsTimeAsBoolean do
       subject { ArticleWithOpposite.new active_at: time }
 
       describe 'calling active' do
-        it { subject.active.should be_true }
+        it { subject.active.should be true }
       end
 
       describe 'calling active?' do
-        it { subject.active?.should be_true }
+        it { subject.active?.should be true }
       end
 
       describe 'calling active=' do
@@ -123,23 +121,23 @@ describe ActAsTimeAsBoolean do
       end
 
       describe 'calling inactive' do
-        it { subject.inactive.should be_false }
+        it { subject.inactive.should be false }
       end
 
       describe 'calling inactive?' do
-        it { subject.inactive?.should be_false }
+        it { subject.inactive?.should be false }
       end
 
       describe 'calling active!' do
         before { subject.active! }
 
-        it { subject.active?.should be_true }
+        it { subject.active?.should be true }
       end
 
       describe 'calling inactive!' do
         before { subject.inactive! }
 
-        it { subject.active?.should be_false }
+        it { subject.active?.should be false }
       end
     end
 
@@ -147,11 +145,11 @@ describe ActAsTimeAsBoolean do
       subject { ArticleWithOpposite.new }
 
       describe 'calling active' do
-        it { subject.active.should be_false }
+        it { subject.active.should be false }
       end
 
       describe 'calling active?' do
-        it { subject.active?.should be_false }
+        it { subject.active?.should be false }
       end
 
       describe 'calling active=' do
@@ -173,23 +171,23 @@ describe ActAsTimeAsBoolean do
       end
 
       describe 'calling inactive' do
-        it { subject.inactive.should be_true }
+        it { subject.inactive.should be true }
       end
 
       describe 'calling inactive?' do
-        it { subject.inactive?.should be_true }
+        it { subject.inactive?.should be true }
       end
 
       describe 'calling active!' do
         before { subject.active! }
 
-        it { subject.active?.should be_true }
+        it { subject.active?.should be true }
       end
 
       describe 'calling inactive!' do
         before { subject.inactive! }
 
-        it { subject.active?.should be_false }
+        it { subject.active?.should be false }
       end
     end
   end

--- a/spec/lib/act_as_time_as_boolean_spec.rb
+++ b/spec/lib/act_as_time_as_boolean_spec.rb
@@ -67,6 +67,22 @@ describe ActAsTimeAsBoolean do
         end
       end
 
+      describe 'with :active param and scope: false' do
+        subject { ArticleWithScopeFalse }
+
+        it 'define active scope' do
+          subject.methods.should_not include(:active)
+        end
+      end
+
+      describe 'with :active param and scope: :reactive' do
+        subject { ArticleWithScope }
+
+        it 'define active scope' do
+          subject.methods.should include(:reactive)
+        end
+      end
+
       describe 'with :active and opposite param' do
         subject { ArticleWithOpposite }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,7 @@
+require 'bundler'
+
+Bundler.require :default, :development
+
 require 'coveralls'
 Coveralls.wear!
 


### PR DESCRIPTION
The code

    time_as_boolean :reject

was causing the following error (since [Rails 5.2](https://github.com/rails/rails/pull/31179)):
 
    You tried to define a scope named "reject" on the model "CarMatcher", but ActiveRecord::Relation already defined an instance method with the same name.

This change allows one to work around this error, either by saying:

    time_as_boolean :reject, scope: false

or alternatively:

    time_as_boolean :reject, scope: :rejected